### PR TITLE
Reuse formatter factory to consolidate module boilerplate

### DIFF
--- a/src/formatGeneratedModule.ts
+++ b/src/formatGeneratedModule.ts
@@ -2,23 +2,36 @@ import { FormatModule } from "relay-compiler";
 import * as ts from "typescript";
 import addAnyTypeCast from "./addAnyTypeCast";
 
+interface FormatterOptions {
+  makeImports: (moduleDetails: Parameters<FormatModule>[0]) => string;
+  append?: string;
+}
+
+const defaultFormatOptions: FormatterOptions = {
+  makeImports({ documentType }) {
+    return documentType
+      ? `import { ${documentType} } from "relay-runtime";`
+      : "";
+  },
+};
+
 export const formatterFactory = (
-  compilerOptions: ts.CompilerOptions = {}
-): FormatModule => ({
-  moduleName,
-  documentType,
-  docText,
-  concreteText,
-  typeText,
-  hash,
-  sourceHash
-}) => {
-  const documentTypeImport = documentType
-    ? `import { ${documentType} } from "relay-runtime";`
-    : "";
+  compilerOptions: ts.CompilerOptions = {},
+  { makeImports }: FormatterOptions = defaultFormatOptions
+): FormatModule => (details) => {
+  const {
+    documentType,
+    docText,
+    concreteText,
+    typeText,
+    hash,
+    sourceHash,
+  } = details;
+
   const docTextComment = docText ? "\n/*\n" + docText.trim() + "\n*/\n" : "";
-  let nodeStatement = `const node: ${documentType ||
-    "never"} = ${concreteText};`;
+  let nodeStatement = `const node: ${
+    documentType || "never"
+  } = ${concreteText};`;
   if (compilerOptions.noImplicitAny) {
     nodeStatement = addAnyTypeCast(nodeStatement).trim();
   }
@@ -26,7 +39,7 @@ export const formatterFactory = (
 /* eslint-disable */
 // @ts-nocheck
 ${hash ? `/* ${hash} */\n` : ""}
-${documentTypeImport}
+${makeImports(details)}
 ${typeText || ""}
 
 ${docTextComment}


### PR DESCRIPTION
Just a bit of cleanup to reuse the formatterFactory that's used in the base to remove that logic from hooks and share the base template between both generation styles.